### PR TITLE
Externally owned container is no longer disposed

### DIFF
--- a/src/NServiceBus.StructureMap.AcceptanceTests/ContainerDecorator.cs
+++ b/src/NServiceBus.StructureMap.AcceptanceTests/ContainerDecorator.cs
@@ -1,0 +1,256 @@
+﻿namespace NServiceBus.StructureMap.AcceptanceTests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using global::StructureMap;
+    using global::StructureMap.Pipeline;
+    using global::StructureMap.Query;
+
+    class ContainerDecorator : IContainer
+    {
+        public ContainerDecorator(IContainer decorated)
+        {
+            this.decorated = decorated;
+        }
+
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            decorated.Dispose();
+            Disposed = true;
+        }
+
+        public T GetInstance<T>()
+        {
+            return decorated.GetInstance<T>();
+        }
+
+        public T GetInstance<T>(string instanceKey)
+        {
+            return decorated.GetInstance<T>(instanceKey);
+        }
+
+        public T GetInstance<T>(Instance instance)
+        {
+            return decorated.GetInstance<T>(instance);
+        }
+
+        public object GetInstance(Type pluginType)
+        {
+            return decorated.GetInstance(pluginType);
+        }
+
+        public object GetInstance(Type pluginType, string instanceKey)
+        {
+            return decorated.GetInstance(pluginType, instanceKey);
+        }
+
+        public object GetInstance(Type pluginType, Instance instance)
+        {
+            return decorated.GetInstance(pluginType, instance);
+        }
+
+        public IEnumerable<T> GetAllInstances<T>()
+        {
+            return decorated.GetAllInstances<T>();
+        }
+
+        public IEnumerable GetAllInstances(Type pluginType)
+        {
+            return decorated.GetAllInstances(pluginType);
+        }
+
+        public T TryGetInstance<T>()
+        {
+            return decorated.TryGetInstance<T>();
+        }
+
+        public T TryGetInstance<T>(string instanceKey)
+        {
+            return decorated.TryGetInstance<T>(instanceKey);
+        }
+
+        public object TryGetInstance(Type pluginType)
+        {
+            return decorated.TryGetInstance(pluginType);
+        }
+
+        public object TryGetInstance(Type pluginType, string instanceKey)
+        {
+            return decorated.TryGetInstance(pluginType, instanceKey);
+        }
+
+        public IEnumerable<T> GetAllInstances<T>(ExplicitArguments args)
+        {
+            return decorated.GetAllInstances<T>(args);
+        }
+
+        public IEnumerable GetAllInstances(Type pluginType, ExplicitArguments args)
+        {
+            return decorated.GetAllInstances(pluginType, args);
+        }
+
+        public T GetInstance<T>(ExplicitArguments args)
+        {
+            return decorated.GetInstance<T>(args);
+        }
+
+        public T GetInstance<T>(ExplicitArguments args, string instanceKey)
+        {
+            return decorated.GetInstance<T>(args, instanceKey);
+        }
+
+        public object GetInstance(Type pluginType, ExplicitArguments args)
+        {
+            return decorated.GetInstance(pluginType, args);
+        }
+
+        public object GetInstance(Type pluginType, ExplicitArguments args, string instanceKey)
+        {
+            return decorated.GetInstance(pluginType, args, instanceKey);
+        }
+
+        public T TryGetInstance<T>(ExplicitArguments args)
+        {
+            return decorated.TryGetInstance<T>(args);
+        }
+
+        public T TryGetInstance<T>(ExplicitArguments args, string instanceKey)
+        {
+            return decorated.TryGetInstance<T>(args, instanceKey);
+        }
+
+        public object TryGetInstance(Type pluginType, ExplicitArguments args)
+        {
+            return decorated.TryGetInstance(pluginType, args);
+        }
+
+        public object TryGetInstance(Type pluginType, ExplicitArguments args, string instanceKey)
+        {
+            return decorated.TryGetInstance(pluginType, args, instanceKey);
+        }
+
+        public void EjectAllInstancesOf<T>()
+        {
+            decorated.EjectAllInstancesOf<T>();
+        }
+
+        public void BuildUp(object target)
+        {
+            decorated.BuildUp(target);
+        }
+
+        public Container.OpenGenericTypeExpression ForGenericType(Type templateType)
+        {
+            return decorated.ForGenericType(templateType);
+        }
+
+        public ExplicitArgsExpression With(Type pluginType, object arg)
+        {
+            return decorated.With(pluginType, arg);
+        }
+
+        public ExplicitArgsExpression With(Action<IExplicitArgsExpression> action)
+        {
+            return decorated.With(action);
+        }
+
+        public ExplicitArgsExpression With<T>(T arg)
+        {
+            return decorated.With(arg);
+        }
+
+        public IExplicitProperty With(string argName)
+        {
+            return decorated.With(argName);
+        }
+
+        public CloseGenericTypeExpression ForObject(object subject)
+        {
+            return decorated.ForObject(subject);
+        }
+
+        public void Configure(Action<ConfigurationExpression> configure)
+        {
+            decorated.Configure(configure);
+        }
+
+        public void Inject<T>(T instance) where T : class
+        {
+            decorated.Inject(instance);
+        }
+
+        public void Inject(Type pluginType, object instance)
+        {
+            decorated.Inject(pluginType, instance);
+        }
+
+        public IContainer GetProfile(string profileName)
+        {
+            return decorated.GetProfile(profileName);
+        }
+
+        public string WhatDoIHave(Type pluginType = null, Assembly assembly = null, string @namespace = null, string typeName = null)
+        {
+            return decorated.WhatDoIHave(pluginType, assembly, @namespace, typeName);
+        }
+
+        public string WhatDidIScan()
+        {
+            return decorated.WhatDidIScan();
+        }
+
+        public void AssertConfigurationIsValid()
+        {
+            decorated.AssertConfigurationIsValid();
+        }
+
+        public IContainer GetNestedContainer()
+        {
+            return decorated.GetNestedContainer();
+        }
+
+        public IContainer GetNestedContainer(string profileName)
+        {
+            return decorated.GetNestedContainer(profileName);
+        }
+
+        public IContainer CreateChildContainer()
+        {
+            return decorated.CreateChildContainer();
+        }
+
+        public void Release(object @object)
+        {
+            decorated.Release(@object);
+        }
+
+        public IContainer GetNestedContainer(TypeArguments arguments)
+        {
+            return decorated.GetNestedContainer(arguments);
+        }
+
+        public IModel Model => decorated.Model;
+
+        public string Name
+        {
+            get { return decorated.Name; }
+            set { decorated.Name = value; }
+        }
+
+        public ContainerRole Role => decorated.Role;
+        public string ProfileName => decorated.ProfileName;
+        public ITransientTracking TransientTracking => decorated.TransientTracking;
+
+        public DisposalLock DisposalLock
+        {
+            get { return decorated.DisposalLock; }
+            set { decorated.DisposalLock = value; }
+        }
+
+        IContainer decorated;
+    }
+}

--- a/src/NServiceBus.StructureMap.AcceptanceTests/NServiceBus.StructureMap.AcceptanceTests.csproj
+++ b/src/NServiceBus.StructureMap.AcceptanceTests/NServiceBus.StructureMap.AcceptanceTests.csproj
@@ -50,6 +50,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StructureMap, Version=4.3.0.449, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StructureMap.4.4.0\lib\net45\StructureMap.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -65,6 +69,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContainerDecorator.cs" />
+    <Compile Include="When_using_externally_owned_container.cs" />
     <Compile Include="DefaultServer.cs" />
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="When_setting_properties_explicitly_via_the_container.cs" />

--- a/src/NServiceBus.StructureMap.AcceptanceTests/When_using_externally_owned_container.cs
+++ b/src/NServiceBus.StructureMap.AcceptanceTests/When_using_externally_owned_container.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.StructureMap.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using global::StructureMap;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_externally_owned_container : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_shutdown_properly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.Decorator.Disposed);
+            Assert.DoesNotThrow(() => context.Container.Dispose());
+        }
+
+        class Context : ScenarioContext
+        {
+            public ContainerDecorator Decorator { get; set; }
+            public IContainer Container { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, desc) =>
+                {
+                    var container = new Container();
+                    var scopeDecorator = new ContainerDecorator(container);
+
+                    config.UseContainer<StructureMapBuilder>(c => c.ExistingContainer(scopeDecorator));
+
+                    var context = (Context)desc.ScenarioContext;
+                    context.Decorator = scopeDecorator;
+                    context.Container = container;
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.StructureMap.AcceptanceTests/packages.config
+++ b/src/NServiceBus.StructureMap.AcceptanceTests/packages.config
@@ -3,4 +3,5 @@
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.AcceptanceTesting" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="StructureMap" version="4.4.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.StructureMap.Tests/DisposeTests.cs
+++ b/src/NServiceBus.StructureMap.Tests/DisposeTests.cs
@@ -1,0 +1,258 @@
+﻿namespace NServiceBus.StructureMap.Tests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using global::StructureMap;
+    using global::StructureMap.Pipeline;
+    using global::StructureMap.Query;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DisposalTests
+    {
+        [Test]
+        public void Owned_container_should_be_disposed()
+        {
+            var fakeScope = new FakeContainer();
+
+            var container = new StructureMapObjectBuilder(fakeScope, true);
+            container.Dispose();
+
+            Assert.True(fakeScope.Disposed);
+        }
+
+        [Test]
+        public void Externally_owned_container_should_not_be_disposed()
+        {
+            var fakeContainer = new FakeContainer();
+
+            var container = new StructureMapObjectBuilder(fakeContainer, false);
+            container.Dispose();
+
+            Assert.False(fakeContainer.Disposed);
+        }
+
+        sealed class FakeContainer : IContainer
+        {
+            public bool Disposed { get; private set; }
+
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+
+            public T GetInstance<T>()
+            {
+                return default(T);
+            }
+
+            public T GetInstance<T>(string instanceKey)
+            {
+                return default(T);
+            }
+
+            public T GetInstance<T>(Instance instance)
+            {
+                return default(T);
+            }
+
+            public object GetInstance(Type pluginType)
+            {
+                return null;
+            }
+
+            public object GetInstance(Type pluginType, string instanceKey)
+            {
+                return null;
+            }
+
+            public object GetInstance(Type pluginType, Instance instance)
+            {
+                return null;
+            }
+
+            public IEnumerable<T> GetAllInstances<T>()
+            {
+                yield break;
+            }
+
+            public IEnumerable GetAllInstances(Type pluginType)
+            {
+                yield break;
+            }
+
+            public T TryGetInstance<T>()
+            {
+                return default(T);
+            }
+
+            public T TryGetInstance<T>(string instanceKey)
+            {
+                return default(T);
+            }
+
+            public object TryGetInstance(Type pluginType)
+            {
+                return null;
+            }
+
+            public object TryGetInstance(Type pluginType, string instanceKey)
+            {
+                return null;
+            }
+
+            public IEnumerable<T> GetAllInstances<T>(ExplicitArguments args)
+            {
+                yield break;
+            }
+
+            public IEnumerable GetAllInstances(Type pluginType, ExplicitArguments args)
+            {
+                yield break;
+            }
+
+            public T GetInstance<T>(ExplicitArguments args)
+            {
+                return default(T);
+            }
+
+            public T GetInstance<T>(ExplicitArguments args, string instanceKey)
+            {
+                return default(T);
+            }
+
+            public object GetInstance(Type pluginType, ExplicitArguments args)
+            {
+                return null;
+            }
+
+            public object GetInstance(Type pluginType, ExplicitArguments args, string instanceKey)
+            {
+                return null;
+            }
+
+            public T TryGetInstance<T>(ExplicitArguments args)
+            {
+                return default(T);
+            }
+
+            public T TryGetInstance<T>(ExplicitArguments args, string instanceKey)
+            {
+                return default(T);
+            }
+
+            public object TryGetInstance(Type pluginType, ExplicitArguments args)
+            {
+                return null;
+            }
+
+            public object TryGetInstance(Type pluginType, ExplicitArguments args, string instanceKey)
+            {
+                return null;
+            }
+
+            public void EjectAllInstancesOf<T>()
+            {
+            }
+
+            public void BuildUp(object target)
+            {
+            }
+
+            public Container.OpenGenericTypeExpression ForGenericType(Type templateType)
+            {
+                return null;
+            }
+
+            public ExplicitArgsExpression With(Type pluginType, object arg)
+            {
+                return null;
+            }
+
+            public ExplicitArgsExpression With(Action<IExplicitArgsExpression> action)
+            {
+                return null;
+            }
+
+            public ExplicitArgsExpression With<T>(T arg)
+            {
+                return null;
+            }
+
+            public IExplicitProperty With(string argName)
+            {
+                return null;
+            }
+
+            public CloseGenericTypeExpression ForObject(object subject)
+            {
+                return null;
+            }
+
+            public void Configure(Action<ConfigurationExpression> configure)
+            {
+            }
+
+            public void Inject<T>(T instance) where T : class
+            {
+            }
+
+            public void Inject(Type pluginType, object instance)
+            {
+            }
+
+            public IContainer GetProfile(string profileName)
+            {
+                return null;
+            }
+
+            public string WhatDoIHave(Type pluginType = null, Assembly assembly = null, string @namespace = null, string typeName = null)
+            {
+                return null;
+            }
+
+            public string WhatDidIScan()
+            {
+                return null;
+            }
+
+            public void AssertConfigurationIsValid()
+            {
+            }
+
+            public IContainer GetNestedContainer()
+            {
+                return null;
+            }
+
+            public IContainer GetNestedContainer(string profileName)
+            {
+                return null;
+            }
+
+            public IContainer CreateChildContainer()
+            {
+                return null;
+            }
+
+            public void Release(object @object)
+            {
+            }
+
+            public IContainer GetNestedContainer(TypeArguments arguments)
+            {
+                return null;
+            }
+
+            public IModel Model { get; }
+            public string Name { get; set; }
+            public ContainerRole Role { get; }
+            public string ProfileName { get; }
+            public ITransientTracking TransientTracking { get; }
+            public DisposalLock DisposalLock { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.StructureMap.Tests/NServiceBus.StructureMap.Tests.csproj
+++ b/src/NServiceBus.StructureMap.Tests/NServiceBus.StructureMap.Tests.csproj
@@ -71,6 +71,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="StructureMap, Version=4.3.0.449, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\StructureMap.4.4.0\lib\net45\StructureMap.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -90,6 +94,7 @@
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_querying_for_registered_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_registering_components.cs" />
     <Compile Include="App_Packages\NSB.ContainerTests.6.0.0-rc0001\When_using_nested_containers.cs" />
+    <Compile Include="DisposeTests.cs" />
     <Compile Include="SetUpFixture.cs" />
     <Compile Include="ShouldNotDisposeTheUnicastBus.cs" />
   </ItemGroup>

--- a/src/NServiceBus.StructureMap.Tests/packages.config
+++ b/src/NServiceBus.StructureMap.Tests/packages.config
@@ -7,4 +7,5 @@
   <package id="NServiceBus" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NServiceBus.ContainerTests.Sources" version="6.0.0-rc0001" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="StructureMap" version="4.4.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.StructureMap.sln.DotSettings
+++ b/src/NServiceBus.StructureMap.sln.DotSettings
@@ -5,6 +5,8 @@
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
+	
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002A_005C_002APackages_005C_002A_002A_005C_002A_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">SUGGESTION</s:String>
@@ -592,6 +594,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	

--- a/src/NServiceBus.StructureMap.sln.DotSettings
+++ b/src/NServiceBus.StructureMap.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
 	
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002A_005C_002APackages_005C_002A_002A_005C_002A_002E_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=3D880FCA_002DD2DA_002D4AB9_002D8017_002DBA8B7C86D359_002Fd_003AApp_005FPackages/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">SUGGESTION</s:String>

--- a/src/NServiceBus.StructureMap/StructureMapBuilder.cs
+++ b/src/NServiceBus.StructureMap/StructureMapBuilder.cs
@@ -17,13 +17,23 @@
         /// <returns>The new container wrapper.</returns>
         public override ObjectBuilder.Common.IContainer CreateContainer(ReadOnlySettings settings)
         {
-            IContainer existingContainer;
-            if (settings.TryGet("ExistingContainer", out existingContainer))
+            ContainerHolder containerHolder;
+            if (settings.TryGet(out containerHolder))
             {
-                return new StructureMapObjectBuilder(existingContainer);
+                return new StructureMapObjectBuilder(containerHolder.ExistingContainer);
             }
 
             return new StructureMapObjectBuilder();
+        }
+
+        internal class ContainerHolder
+        {
+            public ContainerHolder(IContainer container)
+            {
+                ExistingContainer = container;
+            }
+
+            public IContainer ExistingContainer { get; }
         }
     }
 }

--- a/src/NServiceBus.StructureMap/StructureMapExtensions.cs
+++ b/src/NServiceBus.StructureMap/StructureMapExtensions.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         public static void ExistingContainer(this ContainerCustomizations customizations, IContainer container)
         {
-            customizations.Settings.Set("ExistingContainer", container);
+            customizations.Settings.Set<StructureMapBuilder.ContainerHolder>(new StructureMapBuilder.ContainerHolder(container));
         }
     }
 }

--- a/src/NServiceBus.StructureMap/StructureMapObjectBuilder.cs
+++ b/src/NServiceBus.StructureMap/StructureMapObjectBuilder.cs
@@ -9,13 +9,17 @@
 
     class StructureMapObjectBuilder : IContainer
     {
-        public StructureMapObjectBuilder()
+        public StructureMapObjectBuilder() : this(new Container(), true)
         {
-            container = new Container();
         }
 
-        public StructureMapObjectBuilder(global::StructureMap.IContainer container)
+        public StructureMapObjectBuilder(global::StructureMap.IContainer container) : this(container, false)
         {
+        }
+
+        public StructureMapObjectBuilder(global::StructureMap.IContainer container, bool owned)
+        {
+            this.owned = owned;
             this.container = container;
         }
 
@@ -24,9 +28,19 @@
             //Injected at compile time
         }
 
+        void DisposeManaged()
+        {
+            if (!owned)
+            {
+                return;
+            }
+
+            container?.Dispose();
+        }
+
         public IContainer BuildChildContainer()
         {
-            return new StructureMapObjectBuilder(container.GetNestedContainer());
+            return new StructureMapObjectBuilder(container.GetNestedContainer(), true);
         }
 
         public object Build(Type typeToBuild)
@@ -165,5 +179,6 @@
 
         global::StructureMap.IContainer container;
         Dictionary<Type, Instance> configuredInstances = new Dictionary<Type, Instance>();
+        bool owned;
     }
 }


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/4144

If a user passes us in a kernel instance we will not dispose the container instance. We consider that instance externally owned. This is a behavior breaking change. 

I also had to remove the key access since the SettingsHolder automatically disposes settings values that implement `IDisposable`.